### PR TITLE
Fix shebang to be rewritten on install

### DIFF
--- a/script/mojopaste
+++ b/script/mojopaste
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 package App::mojopaste::Backend::File;
 use Mojo::Base 'Mojolicious::Plugin';
 


### PR DESCRIPTION
See https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/58

This is necessary to ensure that the installed script runs with the Perl that was used to install it (and its dependencies).