### PR TITLE
Declare format support for txt pastes

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/app-mojopaste/archive/master.tar.gz
-requires "Mojolicious" => "8.00";
+requires "Mojolicious" => "9.11";
 requires "Text::CSV"   => "1.30";
 
 test_requires "Test::More" => "0.88";

--- a/script/mojopaste
+++ b/script/mojopaste
@@ -112,7 +112,7 @@ post(
 
 get(
   '/:paste_id',
-  [format => ['txt']],
+  [format => ['html', 'txt']],
   {format => undef},
   sub {
     my $c      = shift;

--- a/script/mojopaste
+++ b/script/mojopaste
@@ -112,6 +112,8 @@ post(
 
 get(
   '/:paste_id',
+  [format => ['txt']],
+  {format => undef},
   sub {
     my $c      = shift;
     my $format = $c->stash('format') || '';


### PR DESCRIPTION
Format detection is disabled by default in Mojolicious 9.11. Seems to only be used for txt format of pastes. Fixes #22 